### PR TITLE
Improve Firebase high-score handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
             <div>СЧЁТ: <span id="score">0</span></div>
             <div>УРОВЕНЬ: <span id="level">1</span></div>
             <div>ЖИЗНИ: <span id="lives">3</span></div>
+            <div>РЕКОРД: <span id="highScore">0</span></div>
         </div>
 
         <div id="startScreen">
@@ -25,15 +26,18 @@
             </div>
             <button class="btn" onclick="startGame()">НАЧАТЬ ИГРУ</button>
             <button class="btn" onclick="toggleSound()">ЗВУК: ВКЛ</button>
+            <button class="btn" id="loginBtn" onclick="loginWithGoogle()">ВОЙТИ С GOOGLE</button>
+            <button class="btn" id="logoutBtn" onclick="logout()" style="display:none;">ВЫЙТИ</button>
         </div>
 
         <div id="gameOverScreen" style="display: none;">
             <h1>ИГРА ОКОНЧЕНА</h1>
             <div id="finalScore"></div>
+            <div id="finalHighScore"></div>
             <button class="btn" onclick="restartGame()">ИГРАТЬ СНОВА</button>
         </div>
     </div>
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- correct the Firebase storage bucket domain
- catch Firestore failures and fall back to local storage
- switch to the modular Firebase SDK and expose game functions globally

## Testing
- `npm test` *(fails: no `package.json`)*


------
https://chatgpt.com/codex/tasks/task_e_68497f8e11608330b2320a9297f03a8f