### PR TITLE
feat: add mobile touch support

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
     <title>ARCANOID 90s</title>
     <link rel="stylesheet" href="style.css">
     <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>

--- a/script.js
+++ b/script.js
@@ -628,6 +628,21 @@ document.addEventListener('keyup', (e) => {
     keys[e.key] = false;
 });
 
+// Сенсорное управление для мобильных устройств
+function handleTouch(e) {
+    e.preventDefault();
+    const touch = e.touches[0];
+    const rect = canvas.getBoundingClientRect();
+    const x = ((touch.clientX - rect.left) / rect.width) * canvas.width;
+    paddle.x = Math.min(Math.max(x - paddle.width / 2, 0), canvas.width - paddle.width);
+    if (e.type === 'touchstart' && !ballReleased && gameRunning) {
+        launchBall();
+    }
+}
+
+canvas.addEventListener('touchstart', handleTouch, { passive: false });
+canvas.addEventListener('touchmove', handleTouch, { passive: false });
+
 // Функции управления игрой
 function startGame() {
     initAudio();

--- a/style.css
+++ b/style.css
@@ -17,8 +17,9 @@ body {
 }
 
 #gameContainer {
-    width: 800px;
-    height: 600px;
+    width: 100%;
+    max-width: 800px;
+    aspect-ratio: 4 / 3;
     position: relative;
     border: 3px solid #00ffff;
     box-shadow: 0 0 30px #00ffff, inset 0 0 30px rgba(0, 255, 255, 0.1);
@@ -30,6 +31,7 @@ body {
     height: 100%;
     background: transparent;
     display: block;
+    touch-action: none;
 }
 
 #ui {


### PR DESCRIPTION
## Summary
- make game layout responsive for small screens
- add touch controls and disable zoom on mobile
- restrict touch handlers to canvas so menu buttons remain functional

## Testing
- `node --check script.js`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/popcorn/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a709b08588330ba855629a4d53c96